### PR TITLE
Implement subscription event filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ Subscribe to serverside events:
 -- Subscribe to "state_changed" events
 subscription = WebSocketSubscription(WebSocketSubscription.EVENT_STATE_CHANGED)
 
+-- Filter events based on 'entity_id'
+-- Here, only allow events from 'light.living_room' entity and all in 'media_player' domain
+subscription:filter("light.living_room", "media_player.")
+
 -- Get events in callback
 subscription:on(WebSocketSubscription.CALLBACK_EVENT, function(self, event)
     print(event:getEventData()["entity_id"]) -- entity_id of the entity that changed

--- a/src/WebSocket/WebSocket.ti
+++ b/src/WebSocket/WebSocket.ti
@@ -277,8 +277,29 @@ function WebSocket:handle(e)
 			end
 		elseif event.type == WebSocketMessage.EVENT then
 			-- Find target subscription and execute callbacks
-			if self.subscriptions[event.id] then
-				self.subscriptions[event.id]:executeCallbacks(WebSocketSubscription.CALLBACK_EVENT, event)
+			local sub = self.subscriptions[event.id]
+			if sub then
+				-- If subscription has filters, check it
+				if next(sub.filters) then
+					local data = event:getEventData()
+
+					-- If event data not decoded, bail
+					if not data then return end
+
+					-- Search filters for match
+					local match = false
+					for _, key in ipairs(sub.filters) do
+						if string.find(data["entity_id"], key) then
+							match = true
+							break
+						end
+					end
+
+					-- If no match, drop event
+					if not match then return end
+				end
+
+				sub:executeCallbacks(WebSocketSubscription.CALLBACK_EVENT, event)
 			end
 		end
 

--- a/src/WebSocket/WebSocketSubscription.ti
+++ b/src/WebSocket/WebSocketSubscription.ti
@@ -6,7 +6,7 @@
 --- @field CALLBACK_EVENT string
 --- @field eventType string Event type being subscribed to (see WebSocketSubscription.static for available types)
 --- @field subscribed boolean Whether WebSocket instance has confirmed that this subscription is active
---- @field filters table<string, boolean> If not empty, only allow events from entity_ids in this table
+--- @field filters string[] If not empty, only allow events where entity_id matches any entry (with string.find)
 WebSocketSubscription = {}
 class "WebSocketSubscription" extends "WebSocketRequest" {
 	static = {
@@ -39,11 +39,11 @@ end
 function WebSocketSubscription:filter(ids)
 	if type(ids) == "string" then
 		-- Single filter entry
-		self.filters[ids] = true
+		table.insert(self.filters, ids)
 	elseif type(ids) == "table" then
 		-- Multiple entries in non-indexed table
 		for _, id in ipairs(ids) do
-			self.filters[id] = true
+			table.insert(self.filters, id)
 		end
 	else
 		error("Bad argument #1 to 'filter' (expected string or table, got "..type(ids)..")")

--- a/src/WebSocket/WebSocketSubscription.ti
+++ b/src/WebSocket/WebSocketSubscription.ti
@@ -6,6 +6,7 @@
 --- @field CALLBACK_EVENT string
 --- @field eventType string Event type being subscribed to (see WebSocketSubscription.static for available types)
 --- @field subscribed boolean Whether WebSocket instance has confirmed that this subscription is active
+--- @field filters table<string, boolean> If not empty, only allow events from entity_ids in this table
 WebSocketSubscription = {}
 class "WebSocketSubscription" extends "WebSocketRequest" {
 	static = {
@@ -15,7 +16,9 @@ class "WebSocketSubscription" extends "WebSocketRequest" {
 		CALLBACK_SUBSCRIBED = "subscribed",
 		CALLBACK_UNSUBSCRIBED = "unsubscribed",
 		CALLBACK_EVENT = "event"
-	}
+	},
+
+	filters = {}
 }
 
 --- Resolve constructor arguments
@@ -29,6 +32,22 @@ function WebSocketSubscription:__init__(...)
 		type = self.type,
 		event_type = self.eventType
 	}
+end
+
+--- Add entity_ids to filter
+--- @param ids string|table ids to add to filter
+function WebSocketSubscription:filter(ids)
+	if type(ids) == "string" then
+		-- Single filter entry
+		self.filters[ids] = true
+	elseif type(ids) == "table" then
+		-- Multiple entries in non-indexed table
+		for _, id in ipairs(ids) do
+			self.filters[id] = true
+		end
+	else
+		error("Bad argument #1 to 'filter' (expected string or table, got "..type(ids)..")")
+	end
 end
 
 configureConstructor({

--- a/src/WebSocket/WebSocketSubscription.ti
+++ b/src/WebSocket/WebSocketSubscription.ti
@@ -34,19 +34,16 @@ function WebSocketSubscription:__init__(...)
 	}
 end
 
---- Add entity_ids to filter
---- @param ids string|table ids to add to filter
-function WebSocketSubscription:filter(ids)
-	if type(ids) == "string" then
-		-- Single filter entry
-		table.insert(self.filters, ids)
-	elseif type(ids) == "table" then
-		-- Multiple entries in non-indexed table
-		for _, id in ipairs(ids) do
-			table.insert(self.filters, id)
+--- Add expression(s) to filter list
+--- @vararg string
+function WebSocketSubscription:filter(...)
+	local expressions = {...}
+	for i, expr in ipairs(expressions) do
+		if type(expr) ~= "string" then
+			error("Bad argument #"..i.." to 'filter' (expected string, got "..type(expr)..")")
 		end
-	else
-		error("Bad argument #1 to 'filter' (expected string or table, got "..type(ids)..")")
+
+		table.insert(self.filters, expr)
 	end
 end
 


### PR DESCRIPTION
Filter subscription events by `entity_id` with fuzzy matching. Allows for multiple filters.

Examples:
```lua
-- Only receive state_changed events from 'media_player.living_room'
webSocketSubscription:filter("media_player.living_room")

-- Get events from 'light' and 'cover' domains (entity_ids cannot contain '.' after domain delimiter)
webSocketSubscription:filter({"light.", "cover."})
```