### PR TITLE
Migrate to mixins

### DIFF
--- a/src/WebSocket/WebSocket.ti
+++ b/src/WebSocket/WebSocket.ti
@@ -12,8 +12,8 @@
 --- @field url string @WebSocket endpoint URL (constructor arg 1)
 --- @field apiToken string @Home Assistant API Token (constructor arg 2)
 --- @field application Application @Application instance (constructor arg 3)
---- @field awaitingResult table<number, WebSocketRequest> @Table of requests awaiting a result
---- @field subscriptions table<number, WebSocketSubscription> @Table of currently kept subscriptions
+--- @field awaitingResult table<number, MRequestable> @Table of requests awaiting a result
+--- @field subscriptions table<number, MSubscribable> @Table of currently kept subscriptions
 --- @field ws http.Websocket @WebSocket handle
 --- @field isOpen boolean @Whether the WebSocket connection is open
 --- @field isAuthenticated boolean @Whether server has authenticated our API Token
@@ -127,11 +127,17 @@ end
 
 --- Send a message on the WebSocket connection. **Note**: Calling this function manually
 --- does not provide callbacks for requests and subscriptions, use :request and :subscribe instead
---- @param message WebSocketRequest|table @Message/request to be sent
+--- @param message MRequestable|table @Message/request to be sent
 --- @param noIncrement boolean @If true, don't increment and append command ID
 --- @return number @Assigned command ID (or nil if noIncrement)
 function WebSocket:send(message, noIncrement)
-	if Titanium.typeOf(message, "WebSocketRequest", true) then
+	-- If message is not a table, error
+	if type(message) ~= "table" then
+		error("Bad argument #1 to 'send' (expected table, got "..type(message)..")", 3)
+	end
+
+	-- Lift message out of requestable
+	if Titanium.mixesIn(message, MRequestable.__type) then
 		message = message.message
 	end
 
@@ -184,11 +190,18 @@ function WebSocket:authenticate(authToken)
 end
 
 --- Send a WebSocket request, and listen for responses to it
---- @param request WebSocketRequest @Request to send
+--- @param request MRequestable @Request to send
 --- @return boolean @Request sent
 function WebSocket:request(request)
-	if not Titanium.typeOf(request, "WebSocketRequest", true) then
-		error("Bad argument #1 to 'request' (expected table/WebSocketRequest, got "..type(request)..")")
+	if not Titanium.mixesIn(request, MRequestable.__type) then
+		error("Bad argument #1 to 'request' (expected MRequestable)")
+	end
+
+	-- An active subscription cannot be requested
+	if Titanium.mixesIn(request, MSubscribable.__type) then
+		if request.subscribed then
+			error("Attempt to request a subscription that is active", 3)
+		end
 	end
 
 	local id = self:send(request)
@@ -201,14 +214,16 @@ function WebSocket:request(request)
 end
 
 --- Subscribe to and keep track of a subscription
---- @param subscription WebSocketSubscription @Subscription to subscribe to
+--- @param subscription MSubscribable @Subscription to subscribe to
 --- @return boolean @Subscription was requested
 function WebSocket:subscribe(subscription)
-	if not Titanium.typeOf(subscription, "WebSocketSubscription", true) then
-		error("Bad argument #1 to 'subscribe' (expected table/WebSocketSubscription, got "..type(subscription)..")")
+	if not Titanium.mixesIn(subscription, MSubscribable.__type) then
+		error("Bad argument #1 to 'subscribe' (expected MSubscribable)")
 	end
 
-	if subscription.subscribed then return false end
+	if subscription.subscribed then
+		error("Attempt to subscribe an active subscription", 3)
+	end
 
 	-- Send to get next command ID
 	local id = self:send(subscription)
@@ -216,20 +231,25 @@ function WebSocket:subscribe(subscription)
 
 	-- Add ID to subscription and insert at ID pos in subscriptions
 	subscription.id = id
-	self.subscriptions[id] = subscription
+
+	-- A subscribable is inserted into awaitingResult initially
+	-- When a result returns, it gets moved into subscriptions
+	self.awaitingResult[id] = subscription
 
 	return true
 end
 
 --- Unsubscribe from an active subscription
---- @param subscription WebSocketSubscription @Subscription to unsubscribe from
+--- @param subscription MSubscribable @Subscription to unsubscribe from
 --- @return boolean @Unsubscribe requested
 function WebSocket:unsubscribe(subscription)
-	if not Titanium.typeOf(subscription, "WebSocketSubscription" , true) then
-		error("Bad argument #1 to 'unsubscribe' (expected table/WebSocketSubscription, got "..type(subscription)..")")
+	if not Titanium.mixesIn(subscription, MSubscribable.__type) then
+		error("Bad argument #1 to 'unsubscribe' (expected MSubscribable)")
 	end
 
-	if not subscription.subscribed then return false end
+	if not subscription.subscribed then
+		error("Attempt to unsubscribe an inactive subscription", 3)
+	end
 
 	-- We make our own WebSocketRequest for unsubscribing
 	local unsubReq = WebSocketRequest(WebSocketRequest.UNSUBSCRIBE_EVENTS, {
@@ -237,14 +257,14 @@ function WebSocket:unsubscribe(subscription)
 	})
 
 	-- We need to know if unsubscribing was successful
-	unsubReq:on(WebSocketRequest.CALLBACK_RESULT, function(s, e)
+	unsubReq:doOnResult(function(s, event)
 		local sub = self.subscriptions[s.message.subscription]
-		if e.data["success"] then
-			-- Let listeners know
-			sub.subscribed = false
-			sub:executeCallbacks(WebSocketSubscription.CALLBACK_UNSUBSCRIBED)
+		if event.success then
+			-- HACK: Subscribable may think subscribing failed
+			event.success = false
+			sub:handleResult(event)
 
-			-- Sub finished, remove
+			-- Sub inactive, remove
 			self.subscriptions[s.message.subscription] = nil
 		end
 	end)
@@ -287,20 +307,18 @@ function WebSocket:handle(event)
 			-- Only when authenticated can commands be sent
 			self.isAuthenticated = true
 			self:executeCallbacks(WebSocket.CALLBACK_AUTHENTICATED)
-		elseif message.type == WebSocketMessageEvent.TYPE_EVENT then
-			-- Check if subscription was accepted
-			local sub = self.subscriptions[message.id]
-			-- SUGGEST: Callback if subscription failed?
-			if sub and message.data["success"] then
-				sub.subscribed = true
-				sub:executeCallbacks(WebSocketSubscription.CALLBACK_SUBSCRIBED)
-				return
-			end
-
-			-- Check if request got result
+		elseif message.type == WebSocketMessageEvent.TYPE_RESULT then
 			local req = self.awaitingResult[message.id]
 			if req then
-				req:executeCallbacks(WebSocketRequest.CALLBACK_RESULT, message)
+				-- If request is a subscription, move it to subscriptions
+				if Titanium.mixesIn(req, MSubscribable.__type) then
+					-- Only move if subscribing was successful
+					if message.success then
+						self.subscriptions[req.id] = req
+					end
+				end
+
+				req:handleResult(message)
 
 				-- Requests are one-shot, remove from queue
 				self.awaitingResult[req.id] = nil
@@ -309,7 +327,7 @@ function WebSocket:handle(event)
 			-- Find target subscription and execute callbacks
 			local sub = self.subscriptions[message.id]
 			if sub then
-				sub:handle(message)
+				sub:handleEvent(message)
 			end
 		end
 	elseif event:is(WebSocketSuccessEvent.EVENT_NAME) then

--- a/src/WebSocket/WebSocketRequest.ti
+++ b/src/WebSocket/WebSocketRequest.ti
@@ -38,5 +38,9 @@ function WebSocketRequest:__init__(...)
 end
 
 configureConstructor({
-	orderedArguments = {"type", "message"}
+	orderedArguments = {"type", "message"},
+	argumentTypes = {
+		type = "string",
+		message = "table"
+	}
 })

--- a/src/WebSocket/WebSocketRequest.ti
+++ b/src/WebSocket/WebSocketRequest.ti
@@ -1,6 +1,5 @@
 --- Creates a request with data for sending to Home Assistant instance
---- @class WebSocketRequest : MCallbackManager
---- @field super MCallbackManager
+--- @class WebSocketRequest : MRequestable
 --- @field AUTH string
 --- @field SUBSCRIBE_EVENTS string
 --- @field SUBSCRIBE_TRIGGER string
@@ -11,13 +10,9 @@
 --- @field GET_CONFIG string
 --- @field GET_PANELS string
 --- @field PING string
---- @field CALLBACK_RESULT string
 --- @field VALIDATE_CONFIG string
---- @field type string @Request type (see [WebSocketRequest].static for available types)
---- @field message table @Message (as JSON-able table) to send
---- @field id number @Automatically assigned command ID (given at send-time)
 WebSocketRequest = {}
-class "WebSocketRequest" mixin "MCallbackManager" {
+class "WebSocketRequest" mixin "MRequestable" {
 	static = {
 		AUTH = "auth",
 		SUBSCRIBE_EVENTS = "subscribe_events",
@@ -31,25 +26,15 @@ class "WebSocketRequest" mixin "MCallbackManager" {
 		PING = "ping",
 		VALIDATE_CONFIG = "validate_config",
 
-		CALLBACK_RESULT = "result"
-	},
-
-	message = {}
+		--- @deprecated Use MRequestable.CALLBACK_RESULT instead
+		CALLBACK_RESULT = "callback_result"
+	}
 }
 
 --- Resolve constructor arguments
 --- @vararg any
 function WebSocketRequest:__init__(...)
 	self:resolve(...)
-	self.message.type = self.type
-end
-
---- Attach a callback function to be run when result event occurs
---- @param fn fun(self: WebSocketRequest, result: WebSocketMessageEvent): void @Callback function
---- @param id string @Callback ID
---- @return WebSocketRequest @Self
-function WebSocketRequest:doOnResult(fn, id)
-	return self:on(WebSocketRequest.CALLBACK_RESULT, fn, id)
 end
 
 configureConstructor({

--- a/src/WebSocket/WebSocketSubscription.ti
+++ b/src/WebSocket/WebSocketSubscription.ti
@@ -1,19 +1,19 @@
 --- Manages a WebSocket event subscription, for listening to events on the Home Assistant instance
---- @class WebSocketSubscription : WebSocketRequest
+--- @class WebSocketSubscription : MSubscribable
 --- @field super WebSocketRequest
 --- @field EVENT_STATE_CHANGED string
 --- @field CALLBACK_SUBSCRIBED string
 --- @field CALLBACK_UNSUBSCRIBED string
 --- @field CALLBACK_EVENT string
 --- @field eventType string @Event type being subscribed to (see WebSocketSubscription.static for available types)
---- @field subscribed boolean @Whether WebSocket instance has confirmed that this subscription is active
 --- @field filters string[] @If not empty, only allow events where entity_id matches any entry (with string.find)
 WebSocketSubscription = {}
-class "WebSocketSubscription" extends "WebSocketRequest" {
+class "WebSocketSubscription" mixin "MSubscribable" mixin "MRequestable" {
 	static = {
 		EVENT_STATE_CHANGED = "state_changed",
 		-- TODO: Add event types
 
+		--- @deprecated Use callbacks from MSubscribable instead
 		CALLBACK_SUBSCRIBED = "subscribed",
 		CALLBACK_UNSUBSCRIBED = "unsubscribed",
 		CALLBACK_EVENT = "event"
@@ -27,20 +27,14 @@ class "WebSocketSubscription" extends "WebSocketRequest" {
 function WebSocketSubscription:__init__(...)
 	self:resolve(...)
 	self.type = WebSocketRequest.SUBSCRIBE_EVENTS
+end
 
-	-- Compile request table
+function WebSocketSubscription:getMessage()
 	self.message = {
 		type = self.type,
 		event_type = self.eventType
 	}
-end
-
---- Attach a callback function to be run when an event of the subscribed type occurs
---- @param fn fun(self: WebSocketSubscription, event: WebSocketMessageEvent): void
---- @param id string
---- @return WebSocketRequest
-function WebSocketSubscription:doOnEvent(fn, id)
-	return self:on(WebSocketSubscription.CALLBACK_EVENT, fn, id)
+	return self.message
 end
 
 --- Add expression(s) to filter list
@@ -58,7 +52,7 @@ end
 
 --- Handle a WebSocket message
 --- @param message WebSocketMessageEvent @Message to handle
-function WebSocketSubscription:handle(message)
+function WebSocketSubscription:handleEvent(message)
 	-- If we have filters, handle them
 	if next(self.filters) then
 		local data = message:getEventData()
@@ -79,7 +73,7 @@ function WebSocketSubscription:handle(message)
 		if not match then return end
 	end
 
-	self:executeCallbacks(WebSocketSubscription.CALLBACK_EVENT, message)
+	self:executeCallbacks(MSubscribable.CALLBACK_EVENT, message)
 end
 
 configureConstructor({

--- a/src/WebSocket/WebSocketSubscription.ti
+++ b/src/WebSocket/WebSocketSubscription.ti
@@ -77,5 +77,8 @@ function WebSocketSubscription:handleEvent(message)
 end
 
 configureConstructor({
-	orderedArguments = {"eventType"}
+	orderedArguments = {"eventType"},
+	argumentTypes = {
+		eventType = "string"
+	}
 })

--- a/src/mixin/MRequestable.ti
+++ b/src/mixin/MRequestable.ti
@@ -35,10 +35,3 @@ end
 function MRequestable:handleResult(message)
 	self:executeCallbacks(MRequestable.CALLBACK_RESULT, message)
 end
-
-configureConstructor({
-	argumentTypes = {
-		type = "string",
-		message = "table"
-	}
-})

--- a/src/mixin/MRequestable.ti
+++ b/src/mixin/MRequestable.ti
@@ -1,0 +1,44 @@
+--- Mixin to make an object requestable
+--- @class MRequestable : MCallbackManager
+--- @field CALLBACK_RESULT string
+--- @field public type string @Request type (see [WebSocketRequest].static for available types)
+--- @field public message table @Message (as JSON-able table) to send
+--- @field public id number @Automatically assigned command ID (given at send-time)
+MRequestable = {}
+class "MRequestable" mixin "MCallbackManager" {
+	static = {
+		CALLBACK_RESULT = "result"
+	},
+
+	message = {}
+} abstract()
+
+--- Get message with type merged in
+--- @return table @Merged message
+function MRequestable:getMessage()
+	self.message.type = self.type
+	return self.message
+end
+
+--- Attach a callback function to be run when result event occurs
+--- @generic T : MRequestable
+--- @param s T
+--- @param fn fun(self: T, result: WebSocketMessage): void @Callback function
+--- @param id string @Callback ID
+--- @return T @Self
+function MRequestable.doOnResult(s, fn, id)
+	return s:on(MRequestable.CALLBACK_RESULT, fn, id)
+end
+
+--- Handle result message
+--- @param message WebSocketMessage @Message to handle
+function MRequestable:handleResult(message)
+	self:executeCallbacks(MRequestable.CALLBACK_RESULT, message)
+end
+
+configureConstructor({
+	argumentTypes = {
+		type = "string",
+		message = "table"
+	}
+})

--- a/src/mixin/MRequestable.ti
+++ b/src/mixin/MRequestable.ti
@@ -23,7 +23,7 @@ end
 --- Attach a callback function to be run when result event occurs
 --- @generic T : MRequestable
 --- @param s T
---- @param fn fun(self: T, result: WebSocketMessage): void @Callback function
+--- @param fn fun(self: T, result: WebSocketMessageEvent): void @Callback function
 --- @param id string @Callback ID
 --- @return T @Self
 function MRequestable.doOnResult(s, fn, id)
@@ -31,7 +31,7 @@ function MRequestable.doOnResult(s, fn, id)
 end
 
 --- Handle result message
---- @param message WebSocketMessage @Message to handle
+--- @param message WebSocketMessageEvent @Message to handle
 function MRequestable:handleResult(message)
 	self:executeCallbacks(MRequestable.CALLBACK_RESULT, message)
 end

--- a/src/mixin/MSubscribable.ti
+++ b/src/mixin/MSubscribable.ti
@@ -36,6 +36,9 @@ end
 --- Handle result message
 --- @param message WebSocketMessageEvent @Message to handle
 function MSubscribable:handleResult(message)
+	-- Overrides function in MRequestable
+	self:executeCallbacks(MRequestable.CALLBACK_RESULT, message)
+
 	-- A result for a subscribable can only indicate that subscription status changed
 	if message.success ~= self.subscribed then
 		self.subscribed = message.success

--- a/src/mixin/MSubscribable.ti
+++ b/src/mixin/MSubscribable.ti
@@ -48,9 +48,3 @@ end
 function MSubscribable:handleEvent(message)
 	self:executeCallbacks(MSubscribable.CALLBACK_EVENT, message)
 end
-
-configureConstructor({
-	argumentTypes = {
-		eventType = "string"
-	}
-})

--- a/src/mixin/MSubscribable.ti
+++ b/src/mixin/MSubscribable.ti
@@ -16,7 +16,7 @@ class "MSubscribable" mixin "MRequestable" {
 --- Attach a callback function to be run when an event of the subscribed type occurs
 --- @generic T : MSubscribable
 --- @param s T
---- @param fn fun(self: T, event: WebSocketMessage): void @Callback function
+--- @param fn fun(self: T, event: WebSocketMessageEvent): void @Callback function
 --- @param id string @Callback ID
 --- @return T @Self
 function MSubscribable.doOnEvent(s, fn, id)
@@ -34,7 +34,7 @@ function MSubscribable.doOnSubscriptionChanged(s, fn, id)
 end
 
 --- Handle result message
---- @param message WebSocketMessage @Message to handle
+--- @param message WebSocketMessageEvent @Message to handle
 function MSubscribable:handleResult(message)
 	-- A result for a subscribable can only indicate that subscription status changed
 	if message.success ~= self.subscribed then
@@ -44,7 +44,7 @@ function MSubscribable:handleResult(message)
 end
 
 --- Handle an event message
---- @param message WebSocketMessage @Event message to handle
+--- @param message WebSocketMessageEvent @Event message to handle
 function MSubscribable:handleEvent(message)
 	self:executeCallbacks(MSubscribable.CALLBACK_EVENT, message)
 end

--- a/src/mixin/MSubscribable.ti
+++ b/src/mixin/MSubscribable.ti
@@ -1,0 +1,56 @@
+--- Mixin to make an object subscribable
+--- @class MSubscribable : MRequestable
+--- @field CALLBACK_SUBSCRIPTION_CHANGED string
+--- @field CALLBACK_EVENT string
+--- @field public subscribed boolean @Whether WebSocket instance has confirmed that this subscription is active
+MSubscribable = {}
+class "MSubscribable" mixin "MRequestable" {
+	static = {
+		CALLBACK_SUBSCRIPTION_CHANGED = "subscription_changed",
+		CALLBACK_EVENT = "event",
+	},
+
+	subscribed = false
+} abstract()
+
+--- Attach a callback function to be run when an event of the subscribed type occurs
+--- @generic T : MSubscribable
+--- @param s T
+--- @param fn fun(self: T, event: WebSocketMessage): void @Callback function
+--- @param id string @Callback ID
+--- @return T @Self
+function MSubscribable.doOnEvent(s, fn, id)
+	return s:on(MSubscribable.CALLBACK_EVENT, fn, id)
+end
+
+--- Attach a callback function to be run when subscription status changes
+--- @generic T : MSubscribable
+--- @param s T
+--- @param fn fun(self: T, status: boolean): void @Callback function
+--- @param id string @Callback ID
+--- @return T @Self
+function MSubscribable.doOnSubscriptionChanged(s, fn, id)
+	return s:on(MSubscribable.CALLBACK_SUBSCRIPTION_CHANGED, fn, id)
+end
+
+--- Handle result message
+--- @param message WebSocketMessage @Message to handle
+function MSubscribable:handleResult(message)
+	-- A result for a subscribable can only indicate that subscription status changed
+	if message.success ~= self.subscribed then
+		self.subscribed = message.success
+		self:executeCallbacks(MSubscribable.CALLBACK_SUBSCRIPTION_CHANGED, message.success)
+	end
+end
+
+--- Handle an event message
+--- @param message WebSocketMessage @Event message to handle
+function MSubscribable:handleEvent(message)
+	self:executeCallbacks(MSubscribable.CALLBACK_EVENT, message)
+end
+
+configureConstructor({
+	argumentTypes = {
+		eventType = "string"
+	}
+})


### PR DESCRIPTION
Introduce MRequestable and MSubscribable, which implement the required fields and logic for making an object requestable and subscribable on the WebSocket.
Also modifies WebSocket to utilize mixin types and interfaces.